### PR TITLE
feat: add Storm Glass API config, service, and models

### DIFF
--- a/lib/core/config/stormglass_config.dart
+++ b/lib/core/config/stormglass_config.dart
@@ -1,0 +1,20 @@
+// Configurações da Storm Glass API
+class StormGlassConfig {
+  // Base da API
+  static const String baseUrl = String.fromEnvironment(
+    'STORMGLASS_BASE_URL',
+    defaultValue: 'https://api.stormglass.io',
+  );
+
+  // Versão da API
+  static const String apiV2 = '/v2';
+
+  // Chave da API
+  static const String apiKey = String.fromEnvironment(
+    'STORMGLASS_API_KEY',
+    defaultValue: '',
+  );
+
+  // Fonte padrão
+  static const String defaultSource = 'sg';
+}

--- a/lib/data/services/stormglass_api_service.dart
+++ b/lib/data/services/stormglass_api_service.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:weather_app/core/config/stormglass_config.dart';
+import 'package:weather_app/core/errors/errors_classes.dart';
+
+class StormGlassApiService {
+  final http.Client _client;
+
+  StormGlassApiService({http.Client? client}) : _client = client ?? http.Client();
+
+  Future<Map<String, dynamic>> getMarinePoint(
+    double lat,
+    double lng,
+    DateTime start,
+    DateTime end,
+    List<String> params,
+  ) async {
+    final uri = Uri.parse(
+      '${StormGlassConfig.baseUrl}${StormGlassConfig.apiV2}/marine/point',
+    ).replace(queryParameters: {
+      'lat': lat.toString(),
+      'lng': lng.toString(),
+      'start': start.toUtc().toIso8601String(),
+      'end': end.toUtc().toIso8601String(),
+      'params': params.join(','),
+      'source': StormGlassConfig.defaultSource,
+    });
+
+    final response = await _client.get(uri, headers: _buildHeaders());
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      if (response.body.isEmpty) return {};
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    } else {
+      throw ApiException('Erro na API: ${response.statusCode}');
+    }
+  }
+
+  Future<Map<String, dynamic>> getTideExtremes(
+    double lat,
+    double lng,
+    DateTime start,
+    DateTime end,
+  ) async {
+    final uri = Uri.parse(
+      '${StormGlassConfig.baseUrl}${StormGlassConfig.apiV2}/tide/extremes/point',
+    ).replace(queryParameters: {
+      'lat': lat.toString(),
+      'lng': lng.toString(),
+      'start': start.toUtc().toIso8601String(),
+      'end': end.toUtc().toIso8601String(),
+    });
+
+    final response = await _client.get(uri, headers: _buildHeaders());
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      if (response.body.isEmpty) return {};
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    } else {
+      throw ApiException('Erro na API: ${response.statusCode}');
+    }
+  }
+
+  Map<String, String> _buildHeaders() {
+    final apiKey = StormGlassConfig.apiKey;
+    if (apiKey.isNotEmpty) {
+      return {'Authorization': apiKey};
+    }
+    return {};
+  }
+}
+

--- a/lib/domain/models/marine_models.dart
+++ b/lib/domain/models/marine_models.dart
@@ -1,0 +1,61 @@
+class MarineHour {
+  final DateTime time;
+  final double? waveHeight;
+  final double? swellHeight;
+  final double? swellPeriod;
+  final double? windSpeed;
+  final double? windDirection;
+  final double? waterTemperature;
+
+  const MarineHour({
+    required this.time,
+    this.waveHeight,
+    this.swellHeight,
+    this.swellPeriod,
+    this.windSpeed,
+    this.windDirection,
+    this.waterTemperature,
+  });
+
+  factory MarineHour.fromJson(Map<String, dynamic> json) {
+    double? _valueOf(String key) {
+      final data = json[key];
+      if (data is Map && data['sg'] != null) {
+        final v = data['sg'];
+        if (v is num) return v.toDouble();
+      }
+      return null;
+    }
+
+    return MarineHour(
+      time: DateTime.parse(json['time']),
+      waveHeight: _valueOf('waveHeight'),
+      swellHeight: _valueOf('swellHeight'),
+      swellPeriod: _valueOf('swellPeriod'),
+      windSpeed: _valueOf('windSpeed'),
+      windDirection: _valueOf('windDirection'),
+      waterTemperature: _valueOf('waterTemperature'),
+    );
+  }
+}
+
+class TideExtreme {
+  final DateTime time;
+  final String type; // "low" or "high"
+  final double? height;
+
+  const TideExtreme({
+    required this.time,
+    required this.type,
+    this.height,
+  });
+
+  factory TideExtreme.fromJson(Map<String, dynamic> json) {
+    return TideExtreme(
+      time: DateTime.parse(json['time']),
+      type: json['type'],
+      height: (json['height'] as num?)?.toDouble(),
+    );
+  }
+}
+

--- a/lib/ui/controllers/surf_fish_controller.dart
+++ b/lib/ui/controllers/surf_fish_controller.dart
@@ -1,0 +1,156 @@
+import 'package:weather_app/data/services/stormglass_api_service.dart';
+import 'package:weather_app/domain/models/marine_models.dart';
+
+class SurfFishWindow {
+  final DateTime start;
+  final DateTime end;
+  final String label; // "SURF" or "PESCA"
+  final double score;
+
+  const SurfFishWindow({
+    required this.start,
+    required this.end,
+    required this.label,
+    required this.score,
+  });
+}
+
+class SurfFishController {
+  final StormGlassApiService _api;
+
+  SurfFishController(this._api);
+
+  Future<(
+    List<MarineHour>,
+    List<TideExtreme>,
+    List<SurfFishWindow>,
+  )> load(double lat, double lng) async {
+    final now = DateTime.now().toUtc();
+    final start = DateTime.utc(now.year, now.month, now.day, now.hour);
+    final end = start.add(const Duration(hours: 48));
+
+    const params = [
+      'waveHeight',
+      'swellHeight',
+      'swellPeriod',
+      'windSpeed',
+      'windDirection',
+      'waterTemperature',
+    ];
+
+    final marineJson =
+        await _api.getMarinePoint(lat, lng, start, end, params);
+    final hoursJson = marineJson['hours'] as List<dynamic>? ?? [];
+    final marineHours = hoursJson
+        .map((e) => MarineHour.fromJson(e as Map<String, dynamic>))
+        .toList();
+
+    final tideJson = await _api.getTideExtremes(lat, lng, start, end);
+    final tidesJson = tideJson['data'] as List<dynamic>? ?? [];
+    final tideExtremes = tidesJson
+        .map((e) => TideExtreme.fromJson(e as Map<String, dynamic>))
+        .toList();
+
+    final windows = _calculateWindows(marineHours, tideExtremes);
+
+    return (marineHours, tideExtremes, windows);
+  }
+
+  List<SurfFishWindow> _calculateWindows(
+    List<MarineHour> hours,
+    List<TideExtreme> tides,
+  ) {
+    final windows = <SurfFishWindow>[];
+    DateTime? start;
+    DateTime? end;
+    String? label;
+    double totalScore = 0;
+    int count = 0;
+
+    for (final hour in hours) {
+      final surfScore = _surfScore(hour);
+      final fishScore = _fishScore(hour, tides);
+
+      double? bestScore;
+      String? bestLabel;
+
+      if (surfScore >= fishScore && surfScore >= 3) {
+        bestScore = surfScore;
+        bestLabel = 'SURF';
+      } else if (fishScore > surfScore && fishScore >= 3) {
+        bestScore = fishScore;
+        bestLabel = 'PESCA';
+      }
+
+      if (bestLabel == null) {
+        if (label != null) {
+          windows.add(SurfFishWindow(
+            start: start!,
+            end: end!,
+            label: label!,
+            score: totalScore / count,
+          ));
+          label = null;
+        }
+        continue;
+      }
+
+      if (label == bestLabel &&
+          end != null &&
+          hour.time.difference(end!).inHours == 1) {
+        end = hour.time;
+        totalScore += bestScore!;
+        count++;
+      } else {
+        if (label != null) {
+          windows.add(SurfFishWindow(
+            start: start!,
+            end: end!,
+            label: label!,
+            score: totalScore / count,
+          ));
+        }
+        start = hour.time;
+        end = hour.time;
+        label = bestLabel;
+        totalScore = bestScore!;
+        count = 1;
+      }
+    }
+
+    if (label != null) {
+      windows.add(SurfFishWindow(
+        start: start!,
+        end: end!,
+        label: label!,
+        score: totalScore / count,
+      ));
+    }
+
+    return windows;
+  }
+
+  double _surfScore(MarineHour hour) {
+    double score = 0;
+    if ((hour.swellPeriod ?? 0) >= 8) score++;
+    final swell = hour.swellHeight ?? 0;
+    if (swell >= 0.8 && swell <= 2.2) score++;
+    if ((hour.windSpeed ?? double.infinity) <= 8) score++;
+    return score;
+  }
+
+  double _fishScore(MarineHour hour, List<TideExtreme> tides) {
+    double score = 0;
+    if ((hour.windSpeed ?? double.infinity) <= 6) score++;
+    if ((hour.waveHeight ?? double.infinity) <= 1.5) score++;
+    for (final tide in tides) {
+      final diff = tide.time.difference(hour.time).abs();
+      if (diff <= const Duration(minutes: 90)) {
+        score += 2;
+        break;
+      }
+    }
+    return score;
+  }
+}
+

--- a/lib/ui/widgets/surf_fish_panel.dart
+++ b/lib/ui/widgets/surf_fish_panel.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:weather_app/data/services/stormglass_api_service.dart';
+import 'package:weather_app/ui/controllers/surf_fish_controller.dart';
+import 'package:weather_app/domain/models/marine_models.dart';
+
+class SurfFishPanel extends StatefulWidget {
+  final double lat;
+  final double lng;
+  final StormGlassApiService api;
+
+  const SurfFishPanel({
+    super.key,
+    required this.lat,
+    required this.lng,
+    required this.api,
+  });
+
+  @override
+  State<SurfFishPanel> createState() => _SurfFishPanelState();
+}
+
+class _SurfFishPanelState extends State<SurfFishPanel> {
+  late final SurfFishController _controller;
+  late final Future<(
+    List<MarineHour>,
+    List<TideExtreme>,
+    List<SurfFishWindow>,
+  )> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = SurfFishController(widget.api);
+    _future = _controller.load(widget.lat, widget.lng);
+  }
+
+  String _formatTime(DateTime time) {
+    final t = time.toLocal();
+    String two(int n) => n.toString().padLeft(2, '0');
+    return '${two(t.day)}/${two(t.month)} ${two(t.hour)}:${two(t.minute)}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<(
+      List<MarineHour>,
+      List<TideExtreme>,
+      List<SurfFishWindow>,
+    )>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (snapshot.hasError) {
+          return Center(child: Text('Erro: ${snapshot.error}'));
+        }
+        if (!snapshot.hasData) {
+          return const SizedBox.shrink();
+        }
+        final (
+          List<MarineHour> hours,
+          List<TideExtreme> tides,
+          List<SurfFishWindow> windows,
+        ) = snapshot.data!;
+        final MarineHour? current = hours.isNotEmpty ? hours.first : null;
+
+        return Card(
+          margin: const EdgeInsets.all(16),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Condições atuais',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                if (current != null) ...[
+                  ListTile(
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Onda'),
+                    trailing: Text(
+                      '${current.waveHeight?.toStringAsFixed(1) ?? '--'} m',
+                    ),
+                  ),
+                  ListTile(
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Swell'),
+                    trailing: Text(
+                      '${current.swellHeight?.toStringAsFixed(1) ?? '--'} m / '
+                      '${current.swellPeriod?.toStringAsFixed(0) ?? '--'} s',
+                    ),
+                  ),
+                  ListTile(
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Vento'),
+                    trailing: Text(
+                      '${current.windSpeed?.toStringAsFixed(1) ?? '--'} m/s'
+                      '${current.windDirection != null ? ' (${current.windDirection!.toStringAsFixed(0)}°)' : ''}',
+                    ),
+                  ),
+                  ListTile(
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Água'),
+                    trailing: Text(
+                      '${current.waterTemperature?.toStringAsFixed(1) ?? '--'} °C',
+                    ),
+                  ),
+                ] else
+                  const Text('Sem dados atuais'),
+                const SizedBox(height: 8),
+                ExpansionTile(
+                  title: const Text('Próximas marés'),
+                  children: tides
+                      .map(
+                        (t) => ListTile(
+                          title: Text(t.type == 'high' ? 'Alta' : 'Baixa'),
+                          subtitle: Text(_formatTime(t.time)),
+                          trailing: t.height != null
+                              ? Text('${t.height!.toStringAsFixed(2)} m')
+                              : null,
+                        ),
+                      )
+                      .toList(),
+                ),
+                ExpansionTile(
+                  title: const Text('Janelas ideais'),
+                  children: windows
+                      .map(
+                        (w) => ListTile(
+                          title: Text(
+                            '${w.label} (${w.score.toStringAsFixed(1)})',
+                          ),
+                          subtitle: Text(
+                            '${_formatTime(w.start)} - ${_formatTime(w.end)}',
+                          ),
+                        ),
+                      )
+                      .toList(),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add StormGlassConfig for Storm Glass API settings
- add StormGlassApiService for marine and tide endpoints
- add marine data models for hourly and extreme tide readings
- add SurfFishController to compute surf and fishing windows
- add SurfFishPanel widget to display conditions, tides, and ideal windows

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab15eb646c832eabfc0f7f2fc19f12