### PR TITLE
Add offline mock for StormGlass API

### DIFF
--- a/lib/core/dependencies/injection_dependencies.dart
+++ b/lib/core/dependencies/injection_dependencies.dart
@@ -8,6 +8,7 @@ import 'package:weather_app/domain/usecases/weather_usecases_facade_contract.dar
 import 'package:weather_app/domain/usecases/weather_usecases_facade_impl.dart';
 import 'package:weather_app/domain/usecases/weather_usecases_impl.dart';
 import 'package:weather_app/ui/controllers/home_weather_view_model.dart';
+import 'package:weather_app/ui/controllers/home_page_controller.dart';
 
 final injector = AutoInjector();
 void setupDependencyInjection() {
@@ -32,6 +33,8 @@ void setupDependencyInjection() {
   injector.addSingleton<WeatherHomeViewController>(
     WeatherHomeViewController.new,
   );
+
+  setupHomePageInjection();
 
   injector.commit();
 

--- a/lib/data/services/mock_stormglass_api_service.dart
+++ b/lib/data/services/mock_stormglass_api_service.dart
@@ -1,0 +1,60 @@
+import 'package:weather_app/data/services/stormglass_api_service.dart';
+
+/// A mock implementation of [StormGlassApiService] returning static data.
+class MockStormGlassApiService implements StormGlassApiService {
+  @override
+  Future<Map<String, dynamic>> getMarinePoint(
+    double lat,
+    double lng,
+    DateTime start,
+    DateTime end,
+    List<String> params,
+  ) async {
+    return {
+      'hours': [
+        {
+          'time': start.toIso8601String(),
+          'waveHeight': {'sg': 1.2},
+          'swellHeight': {'sg': 1.0},
+          'swellPeriod': {'sg': 10},
+          'windSpeed': {'sg': 5},
+          'windDirection': {'sg': 180},
+          'waterTemperature': {'sg': 20},
+        },
+        {
+          'time': start.add(const Duration(hours: 1)).toIso8601String(),
+          'waveHeight': {'sg': 1.3},
+          'swellHeight': {'sg': 1.1},
+          'swellPeriod': {'sg': 9},
+          'windSpeed': {'sg': 6},
+          'windDirection': {'sg': 190},
+          'waterTemperature': {'sg': 21},
+        },
+      ],
+    };
+  }
+
+  @override
+  Future<Map<String, dynamic>> getTideExtremes(
+    double lat,
+    double lng,
+    DateTime start,
+    DateTime end,
+  ) async {
+    return {
+      'data': [
+        {
+          'time': start.add(const Duration(hours: 3)).toIso8601String(),
+          'type': 'high',
+          'height': 1.2,
+        },
+        {
+          'time': start.add(const Duration(hours: 9)).toIso8601String(),
+          'type': 'low',
+          'height': 0.1,
+        },
+      ],
+    };
+  }
+}
+

--- a/lib/ui/controllers/home_page_controller.dart
+++ b/lib/ui/controllers/home_page_controller.dart
@@ -1,0 +1,19 @@
+import 'package:http/http.dart' as http;
+import 'package:weather_app/core/config/stormglass_config.dart';
+import 'package:weather_app/core/dependencies/injection_dependencies.dart';
+import 'package:weather_app/data/services/mock_stormglass_api_service.dart';
+import 'package:weather_app/data/services/stormglass_api_service.dart';
+
+/// Registers dependencies for the Home page.
+void setupHomePageInjection() {
+  injector.addSingleton<http.Client>(() => http.Client());
+  if (StormGlassConfig.apiKey.isEmpty) {
+    injector.addSingleton<StormGlassApiService>(
+      () => MockStormGlassApiService(),
+    );
+  } else {
+    injector.addSingleton<StormGlassApiService>(
+      () => StormGlassApiService(client: injector.get<http.Client>()),
+    );
+  }
+}

--- a/lib/ui/views/weather_home_page.dart
+++ b/lib/ui/views/weather_home_page.dart
@@ -7,6 +7,8 @@ import 'package:weather_app/ui/widgets/error_container.dart';
 import 'package:weather_app/ui/widgets/forecast_list.dart';
 import 'package:weather_app/ui/widgets/weather_detail_card.dart';
 import 'package:weather_app/ui/widgets/weather_search_bar.dart';
+import 'package:weather_app/data/services/stormglass_api_service.dart';
+import 'package:weather_app/ui/widgets/surf_fish_panel.dart';
 
 class WeatherHomePage extends StatefulWidget {
   const WeatherHomePage({super.key, required this.title});
@@ -52,6 +54,7 @@ class _WeatherHomePageState extends State<WeatherHomePage> {
 
   @override
   Widget build(BuildContext context) {
+    final sg = injector.get<StormGlassApiService>();
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(
@@ -112,11 +115,16 @@ class _WeatherHomePageState extends State<WeatherHomePage> {
                 // Lista de previsão
                 Watch(
                   (_) =>
-                      _viewController.forecast.value.isNotEmpty 
+                      _viewController.forecast.value.isNotEmpty
                           ? ForecastList(
                             forecasts: _viewController.forecast.value,
                           )
                           : const SizedBox.shrink(),
+                ),
+                SurfFishPanel(
+                  lat: -25.52,
+                  lng: -48.50,
+                  api: sg,
                 ),
               ],
             ),

--- a/lib/ui/widgets/surf_fish_panel.dart
+++ b/lib/ui/widgets/surf_fish_panel.dart
@@ -81,6 +81,7 @@ class _SurfFishPanelState extends State<SurfFishPanel> {
                   ListTile(
                     dense: true,
                     contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.waves),
                     title: const Text('Onda'),
                     trailing: Text(
                       '${current.waveHeight?.toStringAsFixed(1) ?? '--'} m',
@@ -89,6 +90,7 @@ class _SurfFishPanelState extends State<SurfFishPanel> {
                   ListTile(
                     dense: true,
                     contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.trending_up),
                     title: const Text('Swell'),
                     trailing: Text(
                       '${current.swellHeight?.toStringAsFixed(1) ?? '--'} m / '
@@ -98,6 +100,7 @@ class _SurfFishPanelState extends State<SurfFishPanel> {
                   ListTile(
                     dense: true,
                     contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.air),
                     title: const Text('Vento'),
                     trailing: Text(
                       '${current.windSpeed?.toStringAsFixed(1) ?? '--'} m/s'
@@ -107,6 +110,7 @@ class _SurfFishPanelState extends State<SurfFishPanel> {
                   ListTile(
                     dense: true,
                     contentPadding: EdgeInsets.zero,
+                    leading: const Icon(Icons.water),
                     title: const Text('Água'),
                     trailing: Text(
                       '${current.waterTemperature?.toStringAsFixed(1) ?? '--'} °C',
@@ -116,6 +120,7 @@ class _SurfFishPanelState extends State<SurfFishPanel> {
                   const Text('Sem dados atuais'),
                 const SizedBox(height: 8),
                 ExpansionTile(
+                  leading: const Icon(Icons.waves),
                   title: const Text('Próximas marés'),
                   children: tides
                       .map(
@@ -130,6 +135,7 @@ class _SurfFishPanelState extends State<SurfFishPanel> {
                       .toList(),
                 ),
                 ExpansionTile(
+                  leading: const Icon(Icons.access_time),
                   title: const Text('Janelas ideais'),
                   children: windows
                       .map(


### PR DESCRIPTION
## Summary
- Provide static mock implementation of StormGlassApiService
- Register mock when API key is missing to allow offline testing
- Add icons to SurfFishPanel for wave, swell, wind, water, tides and ideal windows

## Testing
- ⚠️ `dart format lib/ui/widgets/surf_fish_panel.dart` (command not found)
- ⚠️ `dart test` (command not found)
- ⚠️ `flutter --version` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ada2b3278c832e8eef4ff209b5bda7