### PR TITLE
feat: use local AsyncState

### DIFF
--- a/lib/ui/controllers/weather_home_view_controller.dart
+++ b/lib/ui/controllers/weather_home_view_controller.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:signals_flutter/signals_flutter.dart';
+import 'package:signals_flutter/signals_flutter.dart' hide AsyncState;
 import 'package:weather_app/core/patterns/command.dart';
 import 'package:weather_app/core/patterns/result.dart';
 import 'package:weather_app/domain/models/current_weather.dart';


### PR DESCRIPTION
## Summary
- hide `AsyncState` from `signals_flutter` in `WeatherHomeViewController`

## Testing
- `flutter analyze` (fails: command not found)
- `dart analyze` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68ae1e5a91b4832e8dcc424f5debf8ce