### PR TITLE
fix: properly cast pollen map

### DIFF
--- a/lib/data/dto/forecast_dto.dart
+++ b/lib/data/dto/forecast_dto.dart
@@ -80,7 +80,7 @@ class ForecastDto {
           as Map<String, dynamic>?,
       pollen: forecast['forecastday'] is List &&
               (forecast['forecastday'] as List).isNotEmpty
-          ? (forecast['forecastday'][0]['day']
+          ? ((forecast['forecastday'] as List)[0]['day']
                   as Map<String, dynamic>?)?['pollen']
               as Map<String, dynamic>?
           : null,


### PR DESCRIPTION
## Summary
- fix pollen field cast in ForecastDto

## Testing
- `dart analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1e695108832ea454e4114243b5e2