### PR TITLE
feat: add surf panel with stormglass service

### DIFF
--- a/lib/core/di/injector.dart
+++ b/lib/core/di/injector.dart
@@ -4,6 +4,7 @@ import 'package:weather_app/data/datasources/weather_mock_datasource.dart';
 import 'package:weather_app/data/datasources/weather_remote_datasource.dart';
 import 'package:weather_app/data/repositories/weather_repository_impl.dart';
 import 'package:weather_app/data/services/api_http_client_service.dart';
+import 'package:weather_app/data/services/stormglass_api_service.dart';
 import 'package:weather_app/domain/repositories/weather_repository.dart';
 import 'package:weather_app/domain/usecases/get_current_weather_usecase.dart';
 import 'package:weather_app/domain/usecases/get_forecast_usecase.dart';
@@ -14,6 +15,8 @@ final injector = AutoInjector();
 
 void initInjector() {
   injector.addSingleton(ApiHttpClientService.new);
+
+  injector.addSingleton(StormGlassApiService.new);
 
   injector.addSingleton<WeatherRemoteDataSource>(
       WeatherApiRemoteDataSource.new);

--- a/lib/data/dto/current_weather_dto.dart
+++ b/lib/data/dto/current_weather_dto.dart
@@ -7,6 +7,8 @@ class CurrentWeatherDto {
   final String iconUrl;
   final int humidity;
   final double windKph;
+  final double lat;
+  final double lon;
 
   const CurrentWeatherDto({
     required this.locationName,
@@ -15,6 +17,8 @@ class CurrentWeatherDto {
     required this.iconUrl,
     required this.humidity,
     required this.windKph,
+    required this.lat,
+    required this.lon,
   });
 
   factory CurrentWeatherDto.fromJson(Map<String, dynamic> j) {
@@ -28,6 +32,8 @@ class CurrentWeatherDto {
       iconUrl: 'https:${condition['icon']}',
       humidity: (current['humidity'] as num?)?.toInt() ?? 0,
       windKph: (current['wind_kph'] as num?)?.toDouble() ?? 0,
+      lat: (location['lat'] as num).toDouble(),
+      lon: (location['lon'] as num).toDouble(),
     );
   }
 
@@ -38,6 +44,8 @@ class CurrentWeatherDto {
         iconUrl: iconUrl,
         humidity: humidity,
         windKph: windKph,
+        lat: lat,
+        lon: lon,
       );
 
   static CurrentWeatherDto mock({String locationName = 'Mock City'}) =>
@@ -49,5 +57,7 @@ class CurrentWeatherDto {
             'https://cdn.weatherapi.com/weather/64x64/day/113.png',
         humidity: 50,
         windKph: 10,
+        lat: 0,
+        lon: 0,
       );
 }

--- a/lib/domain/models/current_weather.dart
+++ b/lib/domain/models/current_weather.dart
@@ -5,6 +5,8 @@ class CurrentWeather {
   final String iconUrl;
   final int humidity;
   final double windKph;
+  final double lat;
+  final double lon;
 
   const CurrentWeather({
     required this.locationName,
@@ -13,5 +15,7 @@ class CurrentWeather {
     required this.iconUrl,
     required this.humidity,
     required this.windKph,
+    required this.lat,
+    required this.lon,
   });
 }

--- a/lib/ui/views/weather_home_page.dart
+++ b/lib/ui/views/weather_home_page.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:signals_flutter/signals_flutter.dart';
 import 'package:weather_app/core/di/injector.dart';
+import 'package:weather_app/data/services/stormglass_api_service.dart';
 import 'package:weather_app/ui/controllers/weather_home_view_controller.dart';
 import 'package:weather_app/ui/widgets/current_weather_card.dart';
 import 'package:weather_app/ui/widgets/forecast_list.dart';
+import 'package:weather_app/ui/widgets/surf_fish_panel.dart';
 import 'package:weather_app/ui/widgets/weather_detail_card.dart';
 import 'package:weather_app/ui/widgets/weather_search_bar.dart';
 
@@ -52,39 +55,70 @@ class _WeatherHomePageState extends State<WeatherHomePage> {
     }
   }
 
+  Widget _buildWeatherTab() {
+    return SafeArea(
+      // use refresh indicator para permitir que o usuário atualize os dados puxando para baixo
+      child: RefreshIndicator(
+        onRefresh: () async {
+          // Aqui você pode chamar o método de atualização de dados
+        },
+        child: SingleChildScrollView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              WeatherSearchBar(
+                controller: searchController,
+                viewController: _viewController,
+                onSearch: _onSearch,
+              ),
+              CurrentWeatherCard(controller: _viewController),
+              const SizedBox(height: 16),
+              WeatherDetailsCard(controller: _viewController),
+              const SizedBox(height: 16),
+              ForecastList(controller: _viewController),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(
-          context,
-        ).colorScheme.primaryContainer.withValues(alpha: 0.1),
-        title: Text(widget.title),
-      ),
-      body: SafeArea(
-        // use refresh indicator para permitir que o usuário atualize os dados puxando para baixo
-        child: RefreshIndicator(
-          onRefresh: () async {
-            // Aqui você pode chamar o método de atualização de dados
-          },
-          child: SingleChildScrollView(
-            physics: const AlwaysScrollableScrollPhysics(),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                WeatherSearchBar(
-                  controller: searchController,
-                  viewController: _viewController,
-                  onSearch: _onSearch,
-                ),
-                CurrentWeatherCard(controller: _viewController),
-                const SizedBox(height: 16),
-                WeatherDetailsCard(controller: _viewController),
-                const SizedBox(height: 16),
-                ForecastList(controller: _viewController),
-              ],
-            ),
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          backgroundColor:
+              Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.1),
+          title: Text(widget.title),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Clima'),
+              Tab(text: 'Surf/Pesca'),
+            ],
           ),
+        ),
+        body: TabBarView(
+          children: [
+            _buildWeatherTab(),
+            Watch((context) {
+              final state = _viewController.currentState.value;
+              if (state.isLoading) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              final weather = state.data;
+              if (weather == null) {
+                return const SizedBox.shrink();
+              }
+              return SurfFishPanel(
+                lat: weather.lat,
+                lng: weather.lon,
+                api: injector.get<StormGlassApiService>(),
+              );
+            }),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- register StormGlassApiService singleton in injector
- extend CurrentWeather with coordinates
- add surf/fish tab showing SurfFishPanel

## Testing
- `dart format lib/core/di/injector.dart lib/domain/models/current_weather.dart lib/data/dto/current_weather_dto.dart lib/ui/views/weather_home_page.dart lib/data/datasources/weather_mock_datasource.dart` (fails: command not found)
- `dart analyze` (fails: command not found)
- `flutter test` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_e_68af5acd55a8832e8214672fe1b5a95f